### PR TITLE
Add Tailwind CSS support for dark theme styling

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,5 @@
+import './globals.css'
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import { isLive, runJob } from "../../lib/lv";
+import { isLive, runJob } from "../lib/lv";
 
 type OCRBox = [number, number, number, number];
 type OCRBlock = { text: string; box: OCRBox };


### PR DESCRIPTION
- Add globals.css with Tailwind directives
- Import CSS in layout.tsx to enable styling
- Fixes dark theme not rendering in production
- Enables proper styling for OCR template demo